### PR TITLE
Sort SMS by part number

### DIFF
--- a/luci-app-sms-tool/luasrc/view/modem/readsms.htm
+++ b/luci-app-sms-tool/luasrc/view/modem/readsms.htm
@@ -109,19 +109,31 @@ tr:nth-child(odd) {background-color: var(--background-color-medium)}
 
 			MergeMySMS.forEach(function (o) {
     			if (!this[o.sender]) {
-        		this[o.sender] = { index: o.index, sender: o.sender, timestamp: o.timestamp, part: o.part, total: o.total, content: o.content };
+    			if(o.part > 0){
+        		this[o.sender] = { index: o.index, sender: o.sender, timestamp: o.timestamp, part: o.part, total: o.total, content: o.content, contentparts: [] };
+        		this[o.sender].contentparts[o.part] = o.content;
+        		}else{
+        		this[o.sender] = { index: o.index, sender: o.sender, timestamp: o.timestamp, part: o.part, total: o.total, content: o.content};
+        		}
         		result.push(this[o.sender]);
         		return;
     			}
 			if (this[o.sender].total == o.total && this[o.sender].timestamp == o.timestamp && this[o.sender].sender == o.sender && this[o.sender].part > 0) {
-    			this[o.sender].index += '-' + o.index;    			
-			this[o.sender].content += o.content;}
+    			this[o.sender].index += '-' + o.index;
+//			this[o.sender].content += o.content;}
+            this[o.sender].contentparts[o.part] = o.content;}
 			else {
 			this[o.sender] = { index: o.index, sender: o.sender, timestamp: o.timestamp, part: o.part, total: o.total, content: o.content };
         		result.push(this[o.sender]);
         		return;
 			}
 			}, Object.create(null));
+			result.forEach(function(o) {
+                if(o.contentparts){
+                    o.contentparts.shift();
+                    o.content = o.contentparts.join('');
+                }
+			});
 
 			var data = JSON.stringify(result);
 			var json = JSON.parse(data);


### PR DESCRIPTION
Sometimes sms_tool with Fibocom L860 return SMS inconsistently, something like
```
id 1 = part 5
id 2 = part 1
id 3 = part 2
id 4 = part 3
id 5 = part 4
```
With 'merge split messages' enabled I got mess like 'part5-part1-part2-part3-part4'.
My JS knowlage is poor, so its a dirty fix for this, but it works. If you can fix it more clear - please close this PR. Thanks.
P.S. Fix didn't tested with other modems, so it may broke something.